### PR TITLE
Update requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.6.0
 Django==4.1.7
-psycopg2-binary==2.9.5
+psycopg2==2.9.5
 python-decouple==3.8
 sqlparse==0.4.3


### PR DESCRIPTION
issue #3 
To integrate PostgreSQL with Django psycopg2 works perfectly in windows but for Linux it's alternative is psycopg2-binary.