### PR TITLE
Add Enrollment Number, Semester, Subject Short Name to Remedial __str__

### DIFF
--- a/backend/core/data/models.py
+++ b/backend/core/data/models.py
@@ -271,7 +271,7 @@ class Attendance(models.Model):
         student_semester_record = self.studentsemesterrecord_set.first()
         if student_semester_record:
             department = student_semester_record.department
-            return f'SEM-{department.semester} {department.name} {self.subject.subject_short_name} {self.date}'
+            return f'SEM-{department.semester} {department.name} RollNo-{student_semester_record.roll_no} {self.subject.subject_short_name} {self.date}'
         else:
             return f'{self.subject.subject_short_name} {self.date}'
 
@@ -290,6 +290,11 @@ class RemedialTestResult(models.Model):
         verbose_name = 'Remedial Test Result'
 
     def __str__(self):
+        test_result = self.testresult_set.first()
+        if test_result:
+            student_semester_record = test_result.studentsemesterrecord_set.first()
+            return_text = f'{student_semester_record.student.enrolment_no} SEM-{student_semester_record.department.semester} {test_result.subject.subject_short_name}'
+            return return_text
         return f'Remedial Test Result {self.id}'
 
 


### PR DESCRIPTION
This PR closes #12 

The Remedial Test Result record was showing a default index e.g. `Remedial Test Result 1`. I added an Enrollment Id, Semester, and Subject Short Name to the record which makes the student distinguish properly.

The Updated Record now looks like `2021002171210121 SEM-4 TOC`.