### PR TITLE
Move callback url to environment variables

### DIFF
--- a/backend/core/authentication/views.py
+++ b/backend/core/authentication/views.py
@@ -1,3 +1,4 @@
+from decouple import config
 from django.shortcuts import render
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
@@ -7,5 +8,5 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 
 class GoogleLoginView(SocialLoginView):
     adapter_class = GoogleOAuth2Adapter
-    callback_url = 'http://127.0.0.1'
+    callback_url = config('GOOGLE_OAUTH2_CALLBACK_URL')
     client_class = OAuth2Client


### PR DESCRIPTION
This PR is an improvement on PR #16 

Remove the hard-coded callback URL in `authentication.views.py` and add it to the environment variable instead.