### PR TITLE
Set Django timezone to Asia/Kolkata

### DIFF
--- a/backend/core/LJConnect/settings.py
+++ b/backend/core/LJConnect/settings.py
@@ -95,7 +95,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Kolkata'
 
 USE_I18N = True
 


### PR DESCRIPTION
This PR closes #37

**Changes**
- timezone is changed to `Asia/Kolkata` from `UTC`.