### PR TITLE
fix pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,24 @@
 exclude: .*migrations\/.*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-    - id: black
-      language_version: python3.10
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
-        name: isort (python)
+        args: ['--profile', 'black']
+
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        language_version: python3.10
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8

--- a/data/admin.py
+++ b/data/admin.py
@@ -1,10 +1,24 @@
 from django.contrib import admin
 
-from .models import (Attendance, Batch, Branch, Department, FacultyAllocation,
-                     GroupProject, IndividualProject, MOOCCourse, MOOCResult,
-                     RemedialTestResult, StaffDetail, StudentDetail,
-                     StudentSemesterRecord, StudyResource, Subject, TestResult,
-                     Weightage)
+from .models import (
+    Attendance,
+    Batch,
+    Branch,
+    Department,
+    FacultyAllocation,
+    GroupProject,
+    IndividualProject,
+    MOOCCourse,
+    MOOCResult,
+    RemedialTestResult,
+    StaffDetail,
+    StudentDetail,
+    StudentSemesterRecord,
+    StudyResource,
+    Subject,
+    TestResult,
+    Weightage,
+)
 
 
 class SemesterSearch:

--- a/data/signals.py
+++ b/data/signals.py
@@ -2,8 +2,13 @@ import json
 from copy import deepcopy
 
 from django.core.serializers import serialize
-from django.db.models.signals import (m2m_changed, post_delete, post_save,
-                                      pre_delete, pre_save)
+from django.db.models.signals import (
+    m2m_changed,
+    post_delete,
+    post_save,
+    pre_delete,
+    pre_save,
+)
 from django.dispatch import receiver
 
 from .models import Batch, Department, FacultyAllocation

--- a/data/tests.py
+++ b/data/tests.py
@@ -2,11 +2,25 @@ import json
 
 from django.test import TestCase
 
-from .models import (Attendance, Batch, Branch, Department, FacultyAllocation,
-                     GroupProject, IndividualProject, MOOCCourse, MOOCResult,
-                     RemedialTestResult, StaffDetail, StudentDetail,
-                     StudentSemesterRecord, StudyResource, Subject, TestResult,
-                     Weightage)
+from .models import (
+    Attendance,
+    Batch,
+    Branch,
+    Department,
+    FacultyAllocation,
+    GroupProject,
+    IndividualProject,
+    MOOCCourse,
+    MOOCResult,
+    RemedialTestResult,
+    StaffDetail,
+    StudentDetail,
+    StudentSemesterRecord,
+    StudyResource,
+    Subject,
+    TestResult,
+    Weightage,
+)
 from .utils import permissions_assign
 
 


### PR DESCRIPTION
This PR closes #82 

## Changes

- Updated pre-commit Configuration for black and isort Compatibility 
- Formatted `admin.py`, `signals.py`, `tests.py` in data app.
